### PR TITLE
Implement login bot webhook

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,6 +21,9 @@
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=14.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,9 @@
     "start": "node ./registerWebhook.mjs && next start",
     "lint": "next lint"
   },
+  "engines": {
+    "node": ">=14.8.0"
+  },
   "dependencies": {
     "next": "15.3.3",
     "react": "^19.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "node ./registerWebhook.mjs && next dev --turbopack",
     "build": "next build",
-    "start": "next start",
+    "start": "node ./registerWebhook.mjs && next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/app/registerWebhook.mjs
+++ b/app/registerWebhook.mjs
@@ -1,5 +1,6 @@
 import { Telegraf } from 'telegraf';
 import crypto from 'crypto';
+import { URL } from 'url';
 
 const token = process.env.BOT_TOKEN;
 const base = process.env.BASE_URL;
@@ -11,13 +12,20 @@ if (!token || !base || !secret) {
 }
 
 const hash = crypto.createHash('sha256').update(token).digest('hex').slice(0, 16);
-const path = `api/webhook/${hash}`;
-const url = `${base.replace(/\/$/, '')}/${path}`;
+let urlStr;
+try {
+  const baseUrl = new URL(base);
+  const webhookUrl = new URL(`api/webhook/${hash}`, baseUrl);
+  urlStr = webhookUrl.toString();
+} catch {
+  console.error('BASE_URL must be a valid absolute URL');
+  process.exit(1);
+}
 
 const bot = new Telegraf(token);
 try {
-  await bot.telegram.setWebhook(url, { secret_token: secret });
-  console.log('Webhook registered', url);
+  await bot.telegram.setWebhook(urlStr, { secret_token: secret });
+  console.log('Webhook registered', urlStr);
 } catch (err) {
   console.error('Failed to set webhook', err);
   process.exit(1);

--- a/app/registerWebhook.mjs
+++ b/app/registerWebhook.mjs
@@ -1,0 +1,25 @@
+import { Telegraf } from 'telegraf';
+import crypto from 'crypto';
+
+const token = process.env.BOT_TOKEN;
+const base = process.env.BASE_URL;
+const secret = process.env.WEBHOOK_SECRET;
+
+if (!token || !base || !secret) {
+  console.error('BOT_TOKEN, BASE_URL, and WEBHOOK_SECRET must be set');
+  process.exit(1);
+}
+
+const hash = crypto.createHash('sha256').update(token).digest('hex').slice(0, 16);
+const path = `api/webhook/${hash}`;
+const url = `${base.replace(/\/$/, '')}/${path}`;
+
+const bot = new Telegraf(token);
+try {
+  await bot.telegram.setWebhook(url, { secret_token: secret });
+  console.log('Webhook registered', url);
+} catch (err) {
+  console.error('Failed to set webhook', err);
+  process.exit(1);
+}
+

--- a/app/src/app/api/auth/telegram/route.ts
+++ b/app/src/app/api/auth/telegram/route.ts
@@ -2,21 +2,34 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifyTelegramAuth } from "@/lib/verifyTelegram";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
+  const { searchParams } = new URL(req.url);
+  const token = searchParams.get('token');
+  const chatId = searchParams.get('chat_id');
+  if (!token || !chatId) {
+    return NextResponse.json({ error: 'token and chat_id required' }, { status: 400 });
+  }
+  const tokenPattern = /^\d+:[A-Za-z0-9_-]{35,}$/;
+  if (!tokenPattern.test(token)) {
+    return NextResponse.json({ error: 'invalid token' }, { status: 400 });
+  }
+  if (!/^-?\d+$/.test(chatId)) {
+    return NextResponse.json({ error: 'invalid chat_id' }, { status: 400 });
+  }
   const params: Record<string, string> = {};
-  url.searchParams.forEach((v, k) => {
-    params[k] = v;
+  searchParams.forEach((v, k) => {
+    if (k !== 'token' && k !== 'chat_id') params[k] = v;
   });
-  const token = process.env.BOT_TOKEN;
-  if (!token) return NextResponse.json({ error: "BOT_TOKEN not configured" }, { status: 500 });
+  const botToken = process.env.BOT_TOKEN;
+  if (!botToken)
+    return NextResponse.json({ error: 'BOT_TOKEN not configured' }, { status: 500 });
   let ok = false;
   try {
-    ok = verifyTelegramAuth(params, token);
+    ok = verifyTelegramAuth(params, botToken);
   } catch (err) {
-    console.error("verifyTelegramAuth error", err);
-    return NextResponse.json({ error: "verification failed" }, { status: 400 });
+    console.error('verifyTelegramAuth error', err);
+    return NextResponse.json({ error: 'verification failed' }, { status: 400 });
   }
-  if (!ok) return NextResponse.json({ ok: false }, { status: 401 });
+  if (!ok) return NextResponse.json({ error: 'invalid hash' }, { status: 401 });
   const user = {
     id: params.id,
     first_name: params.first_name,

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type TgUser = {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+};
+
+export default function LoginPage() {
+  const [status, setStatus] = useState<'loading' | 'error' | 'ok'>('loading');
+  const [message, setMessage] = useState('');
+  const [user, setUser] = useState<TgUser | null>(null);
+
+  useEffect(() => {
+    const params = window.location.search.slice(1);
+    if (!params) {
+      setStatus('error');
+      setMessage('missing auth data');
+      return;
+    }
+    fetch('/api/auth/telegram?' + params)
+      .then(r => r.json())
+      .then(data => {
+        if (data.ok) {
+          setUser(data.user);
+          setStatus('ok');
+        } else {
+          setStatus('error');
+          setMessage(data.error || 'login failed');
+        }
+      })
+      .catch(() => {
+        setStatus('error');
+        setMessage('login failed');
+      });
+  }, []);
+
+  if (status === 'loading') return <main style={{padding:'2rem'}}>Logging in…</main>;
+  if (status === 'error') return <main style={{padding:'2rem'}}>Error: {message}</main>;
+  return (
+    <main style={{padding:'2rem'}}>
+      <h1>Logged in</h1>
+      <p>Welcome, {user.first_name}</p>
+    </main>
+  );
+}
+

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -14,13 +14,20 @@ export default function LoginPage() {
   const [user, setUser] = useState<TgUser | null>(null);
 
   useEffect(() => {
-    const params = window.location.search.slice(1);
-    if (!params) {
+    const search = window.location.search;
+    if (!search) {
       setStatus('error');
       setMessage('missing auth data');
       return;
     }
-    fetch('/api/auth/telegram?' + params)
+    const urlParams = new URLSearchParams(search);
+    if (!urlParams.get('token') || !urlParams.get('chat_id')) {
+      setStatus('error');
+      setMessage('invalid parameters');
+      return;
+    }
+    const qs = urlParams.toString();
+    fetch('/api/auth/telegram?' + qs)
       .then(r => r.json())
       .then(data => {
         if (data.ok) {


### PR DESCRIPTION
## Summary
- automatically register webhook for BOT_TOKEN on startup
- handle global bot updates to send login link
- add login page for Telegram login flow

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f8bb965a88328bd2c820c80831ab4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added Telegram-based user login with a dedicated login page that provides feedback on login status.
	- Implemented automatic Telegram webhook registration for streamlined bot integration.
	- Enhanced API endpoints with improved validation and standardized error responses for Telegram authentication.

- **Bug Fixes**
	- Improved webhook handling to ensure messages are sent only when the correct webhook ID is matched and errors are logged appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->