### PR TITLE
Fix dynamic route error in webhook

### DIFF
--- a/src/app/api/webhook/[id]/route.ts
+++ b/src/app/api/webhook/[id]/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+
+// Ensure this route is treated as dynamic so `params` can be read synchronously
+export const dynamic = "force-dynamic";
 import { Telegraf } from "telegraf";
 import crypto from "crypto";
 


### PR DESCRIPTION
## Summary
- mark `api/webhook/[id]` as dynamic so `params` can be accessed synchronously

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f919715848328b56dc341c68f16dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated route configuration to improve dynamic handling for webhook endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->