### PR TITLE
Add bots management page

### DIFF
--- a/src/app/api/bot/register/route.ts
+++ b/src/app/api/bot/register/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const apiKey = process.env.API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ error: 'server misconfigured' }, { status: 500 })
+  }
+  let token: string
+  try {
+    ;({ token } = await req.json())
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 })
+  }
+  const url = new URL('/api/bot', req.url)
+  const res = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify({ token }),
+  })
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/src/app/bots/page.tsx
+++ b/src/app/bots/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+interface Bot {
+  token: string;
+  webhook?: string;
+  path?: string;
+}
+
+export default function BotsPage() {
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [token, setToken] = useState('');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('bots');
+      if (stored) setBots(JSON.parse(stored));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('bots', JSON.stringify(bots));
+    } catch {}
+  }, [bots]);
+
+  async function register() {
+    if (!token) return;
+    setLoading(true);
+    setStatus('');
+    try {
+      const res = await fetch('/api/bot', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': process.env.NEXT_PUBLIC_API_KEY || '',
+        },
+        body: JSON.stringify({ token }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setBots([...bots, { token, webhook: data.webhook, path: data.path }]);
+        setToken('');
+        setStatus('Bot registered');
+      } else {
+        setStatus(data.error || 'Failed to register');
+      }
+    } catch {
+      setStatus('Request failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Your Bots</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="text"
+          value={token}
+          onChange={e => setToken(e.target.value)}
+          placeholder="Bot token"
+        />
+        <button onClick={register} disabled={loading || !token} style={{ marginLeft: '0.5rem' }}>
+          Register
+        </button>
+        {status && <p>{status}</p>}
+      </div>
+      <ul>
+        {bots.map((b, i) => (
+          <li key={i} style={{ marginBottom: '1rem' }}>
+            <div>Token: {b.token}</div>
+            {b.webhook && <div>Webhook: {b.webhook}</div>}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/app/bots/page.tsx
+++ b/src/app/bots/page.tsx
@@ -28,14 +28,17 @@ export default function BotsPage() {
 
   async function register() {
     if (!token) return;
+    if (bots.some(b => b.token === token)) {
+      setStatus('Bot already added');
+      return;
+    }
     setLoading(true);
     setStatus('');
     try {
-      const res = await fetch('/api/bot', {
+      const res = await fetch('/api/bot/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-api-key': process.env.NEXT_PUBLIC_API_KEY || '',
         },
         body: JSON.stringify({ token }),
       });
@@ -70,8 +73,8 @@ export default function BotsPage() {
         {status && <p>{status}</p>}
       </div>
       <ul>
-        {bots.map((b, i) => (
-          <li key={i} style={{ marginBottom: '1rem' }}>
+        {bots.map(b => (
+          <li key={b.token} style={{ marginBottom: '1rem' }}>
             <div>Token: {b.token}</div>
             {b.webhook && <div>Webhook: {b.webhook}</div>}
           </li>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 type TgUser = {
   id: number;
@@ -12,6 +13,7 @@ export default function LoginPage() {
   const [status, setStatus] = useState<'loading' | 'error' | 'ok'>('loading');
   const [message, setMessage] = useState('');
   const [user, setUser] = useState<TgUser | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const search = window.location.search;
@@ -42,6 +44,10 @@ export default function LoginPage() {
         if (data.ok) {
           setUser(data.user);
           setStatus('ok');
+          try {
+            localStorage.setItem('tgUser', JSON.stringify(data.user));
+          } catch {}
+          router.replace('/bots');
         } else {
           setStatus('error');
           setMessage(data.error || 'login failed');


### PR DESCRIPTION
## Summary
- create `/bots` page for managing bot tokens
- redirect login flow to `/bots`

## Testing
- `npx -y tsx --test test/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_683fa0234adc8328a13e48ac605dc7cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Bots page for managing a list of bots, including bot registration, token input, status messages, and persistent storage.
- **Improvements**
  - Enhanced login experience by automatically redirecting users to the Bots page after successful login verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->