### PR TITLE
Use user-specific login secret

### DIFF
--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,24 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Telegraf } from "telegraf";
+import { loginSecret } from "@/lib/loginSecret";
 
 export async function POST(req: NextRequest) {
-  const secret = process.env.WEBHOOK_SECRET;
   const token = process.env.BOT_TOKEN;
 
-  if (!secret || !token) {
+  if (!token) {
     return NextResponse.json({ error: "server misconfigured" }, { status: 500 });
   }
 
   try {
     const body = await req.json();
-    if (body.secret !== secret) {
-      return NextResponse.json({ error: "invalid secret" }, { status: 401 });
-    }
 
     // Get the chat ID from the request
     const chatId = body.chatId;
     if (!chatId) {
       return NextResponse.json({ error: "missing chat ID" }, { status: 400 });
+    }
+    const expected = loginSecret(token, chatId);
+    if (body.secret !== expected) {
+      return NextResponse.json({ error: "invalid secret" }, { status: 401 });
     }
 
     // Initialize the bot

--- a/src/app/api/webhook/[id]/route.ts
+++ b/src/app/api/webhook/[id]/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 import { Telegraf } from "telegraf";
 import crypto from "crypto";
+import { loginSecret } from "@/lib/loginSecret";
 
 const secret = process.env.WEBHOOK_SECRET;
 const token = process.env.BOT_TOKEN;
@@ -61,7 +62,7 @@ export async function POST(
     console.log("loginUrl", loginUrl);
     if (chatId) {
       try {
-        const loginUrlWithSecret = `${loginUrl}?secret=${secret}&chatId=${chatId}`;
+        const loginUrlWithSecret = `${loginUrl}?secret=${loginSecret(token!, chatId)}&chatId=${chatId}`;
         await bot.telegram.sendMessage(chatId, "Use this link to log in:", {
           reply_markup: {
             inline_keyboard: [

--- a/src/lib/loginSecret.ts
+++ b/src/lib/loginSecret.ts
@@ -1,0 +1,5 @@
+import crypto from 'crypto';
+
+export function loginSecret(botToken: string, userId: string | number): string {
+  return crypto.createHash('sha256').update(botToken + String(userId)).digest('hex');
+}

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 import { verifyTelegramAuth } from '../src/lib/verifyTelegram';
 import { schulze, Ballot } from '../src/lib/schulze';
 import { createVote, addBallot, getResults } from '../src/lib/store';
+import { loginSecret } from '../src/lib/loginSecret';
 
 
 test('verifyTelegramAuth valid hash', () => {
@@ -51,4 +52,12 @@ test('store vote lifecycle', () => {
   assert.equal(addBallot(vote.id, ballot), true);
   assert.deepEqual(getResults(vote.id), ['A', 'B', 'C']);
   assert.equal(addBallot('nonexistent', ballot), false);
+});
+
+test('loginSecret generates user specific secret', () => {
+  const token = 'TESTTOKEN';
+  const userId = 42;
+  const expected = crypto.createHash('sha256').update(token + String(userId)).digest('hex');
+  assert.equal(loginSecret(token, userId), expected);
+  assert.notEqual(loginSecret(token, userId), loginSecret(token, userId + 1));
 });


### PR DESCRIPTION
## Summary
- make login secret depend on the Telegram user id
- add helper `loginSecret()`
- test new secret logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa31726588328a1e4657c0eed84c8