### PR TITLE
Add user navbar and logout page

### DIFF
--- a/src/app/Navbar.tsx
+++ b/src/app/Navbar.tsx
@@ -1,0 +1,38 @@
+'use client';
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+
+export type TgUser = {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+};
+
+export default function Navbar() {
+  const [user, setUser] = useState<TgUser | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('tgUser');
+      if (stored) setUser(JSON.parse(stored));
+    } catch {}
+  }, []);
+
+  return (
+    <nav className="navbar">
+      <Link href="/" className="nav-link">Home</Link>
+      <Link href="/bots" className="nav-link">Bots</Link>
+      <div className="nav-user">
+        {user ? (
+          <>
+            <span className="nav-user-name">Logged in as {user.first_name}</span>
+            <Link href="/logout" className="nav-link">Logout</Link>
+          </>
+        ) : (
+          <Link href="/login" className="nav-link">Login</Link>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,6 +35,22 @@ a {
   text-decoration: none;
 }
 
+nav.navbar {
+  display: flex;
+  padding: 1rem;
+  background: #eee;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 2rem;
+}
+
+.navbar .nav-link {
+  margin-right: 1rem;
+}
+
+.navbar .nav-user {
+  margin-left: auto;
+}
+
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "./Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,6 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <Navbar />
         {children}
       </body>
     </html>

--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LogoutPage() {
+  const router = useRouter();
+  useEffect(() => {
+    try {
+      localStorage.removeItem('tgUser');
+      localStorage.removeItem('bots');
+    } catch {}
+    router.replace('/');
+  }, [router]);
+
+  return <main style={{ padding: '2rem' }}>Logging out…</main>;
+}


### PR DESCRIPTION
## Summary
- add Navbar component that shows current user info and logout link
- include Navbar in the layout
- create a logout page clearing localStorage
- style navbar via globals.css

## Testing
- `npx --yes vitest run` *(fails: Cannot find package 'next/server')*

------
https://chatgpt.com/codex/tasks/task_e_683fa8c45b68832887c87eb67bd300eb