### PR TITLE
Implement auth middleware for API

### DIFF
--- a/src/app/api/webhook/[id]/route.ts
+++ b/src/app/api/webhook/[id]/route.ts
@@ -68,12 +68,12 @@ export async function POST(
     const update = body as {
       message?: { chat?: { id?: number } };
     };
-    const chatId = update.message?.chat?.id;
+    const userId = update.message?.chat?.id;
     console.log("loginUrl", loginUrl);
-    if (chatId) {
+    if (userId) {
       try {
-        const loginUrlWithSecret = `${loginUrl}?secret=${loginSecret(token!, chatId)}&chatId=${chatId}`;
-        await bot.telegram.sendMessage(chatId, "Use this link to log in:", {
+        const loginUrlWithSecret = `${loginUrl}?secret=${loginSecret(token!, userId)}&userId=${userId}`;
+        await bot.telegram.sendMessage(userId, "Use this link to log in:", {
           reply_markup: {
             inline_keyboard: [
               [

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -24,9 +24,9 @@ export default function LoginPage() {
     }
     const urlParams = new URLSearchParams(search);
     const secret = urlParams.get('secret');
-    const chatId = urlParams.get('chatId');
-    
-    if (!secret || !chatId) {
+    const userId = urlParams.get('userId');
+
+    if (!secret || !userId) {
       setStatus('error');
       setMessage('missing required parameters');
       return;
@@ -37,7 +37,7 @@ export default function LoginPage() {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ secret, chatId: parseInt(chatId, 10) }),
+      body: JSON.stringify({ secret, userId: parseInt(userId, 10) }),
     })
       .then(r => r.json())
       .then(data => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loginSecret } from '@/lib/loginSecret';
+
+export default function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/api/webhook')) {
+    const apiKey = req.headers.get('x-api-key');
+    if (!apiKey || apiKey !== process.env.API_KEY) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith('/api') && !pathname.startsWith('/api/auth')) {
+    const token = process.env.BOT_TOKEN;
+    if (!token) {
+      return NextResponse.json({ error: 'server misconfigured' }, { status: 500 });
+    }
+    const secret = req.cookies.get('loginsecret')?.value;
+    const userId = req.cookies.get('userId')?.value;
+    if (!secret || !userId || secret !== loginSecret(token, userId)) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+};

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -45,8 +45,8 @@ describe('webhook handler', () => {
   });
 
   it('start message sends login link', async () => {
-    const chatId = 42;
-    const body = { update_id: 1, message: { chat: { id: chatId } } };
+    const userId = 42;
+    const body = { update_id: 1, message: { chat: { id: userId } } };
     const req = new NextRequest('http://localhost/api/webhook/' + mod.__getState().mainId, {
       method: 'POST',
       headers: { 'x-telegram-bot-api-secret-token': SECRET },
@@ -59,13 +59,13 @@ describe('webhook handler', () => {
     expect(res.status).toBe(200);
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
-      chatId,
+      userId,
       'Use this link to log in:',
       {
         reply_markup: {
           inline_keyboard: [[{
             text: 'Log in',
-            url: `${mod.__getState().loginUrl}?secret=${loginSecret(TOKEN, chatId)}&chatId=${chatId}`
+            url: `${mod.__getState().loginUrl}?secret=${loginSecret(TOKEN, userId)}&userId=${userId}`
           }]]
         }
       }


### PR DESCRIPTION
## Summary
- add middleware requiring login secret cookies for most API routes
- secure webhook route by checking `x-api-key`
- set login cookies in the auth verify endpoint
- rename `chatId` authentication parameter to `userId`

## Testing
- `npm test` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_684036660ff0832896eccb49425fc45c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced authorization checks for API routes, including cookie-based authentication and API key validation for webhooks.

- **Bug Fixes**
	- Improved consistency by standardizing the use of `userId` instead of `chatId` across login and authentication flows.

- **Tests**
	- Updated test cases to reflect the change from `chatId` to `userId` for improved clarity and alignment with authentication logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->